### PR TITLE
added comments in places that probably should be refactored

### DIFF
--- a/cache/cache-common/src/main/java/com/github/e13mort/codeview/cache/CachedCVTransformation.kt
+++ b/cache/cache-common/src/main/java/com/github/e13mort/codeview/cache/CachedCVTransformation.kt
@@ -22,12 +22,14 @@ class CachedCVTransformation<INPUT, OUTPUT>(
         return if (cacheResult.fromCache) {
             Single.just(transformOperation)
         } else {
+            //FIXME Save operation should return content of cached operation somehow. Otherwise we'll make transformation even after caching
             save(transformOperation).map { transformOperation }
         }
     }
 
-    private fun save(transformOperation: CVTransformation.TransformOperation<OUTPUT>): Single<ContentStorage.ContentStorageItem> {
-        return storage.put(
+   private fun save(transformOperation: CVTransformation.TransformOperation<OUTPUT>): Single<ContentStorage.ContentStorageItem> {
+       //FIXME maybe you should return content of cached operation from put method and wrap it with DumbTransformOperation
+       return storage.put(
             transformOperation.description(),
             transformOperation
                 .transform()
@@ -76,6 +78,7 @@ class CachedCVTransformation<INPUT, OUTPUT>(
     interface CVSerialization<INPUT> {
         fun serialize(input: INPUT): Content
 
+        //FIXME it's seems that there is should be content in arguments
         fun deserialize(path: Path): INPUT
     }
 }

--- a/cache/cache-common/src/main/java/com/github/e13mort/codeview/cache/CachedCVTransformation.kt
+++ b/cache/cache-common/src/main/java/com/github/e13mort/codeview/cache/CachedCVTransformation.kt
@@ -2,6 +2,7 @@ package com.github.e13mort.codeview.cache
 
 import com.github.e13mort.codeview.CVTransformation
 import com.github.e13mort.codeview.Content
+import io.reactivex.Observable
 import io.reactivex.Single
 import java.nio.file.Path
 
@@ -23,13 +24,25 @@ class CachedCVTransformation<INPUT, OUTPUT>(
             Single.just(transformOperation)
         } else {
             //FIXME Save operation should return content of cached operation somehow. Otherwise we'll make transformation even after caching
-            save(transformOperation).map { transformOperation }
+            save(transformOperation).map { transformOperation } //OR second solution without map
         }
         //OR if we use fast hacky solution we just return Single.just(cacheResult.cachedOperation)
     }
 
-    private fun save(transformOperation: CVTransformation.TransformOperation<OUTPUT>): Single<ContentStorage.ContentStorageItem> {
+    private fun save(transformOperation: CVTransformation.TransformOperation<OUTPUT>): /*Single<CVTransformation.TransformOperation<OUTPUT>>*/Single<ContentStorage.ContentStorageItem> {
+// OR second solution, when we serialize and save result of transformation in doOnSuccess
+//        return transformOperation
+//            .transform()
+//            .doOnSuccess {
+//                storage.put(
+//                    transformOperation.description(),
+//                    Observable.fromCallable { serialization.serialize(it) }
+//
+//                )
+//            }
+//            .map { DumbTransformOperation(it, transformOperation.description()) }
         //FIXME maybe you should return content of cached operation from put method and wrap it with DumbTransformOperation
+
         return storage.put(
             transformOperation.description(),
             transformOperation
@@ -42,15 +55,15 @@ class CachedCVTransformation<INPUT, OUTPUT>(
     private fun searchForItem(sourceOperation: CVTransformation.TransformOperation<OUTPUT>): Single<CacheResult<OUTPUT>> {
         return storage
             .search(sourceOperation.description())
-           //OR we can just save this operation if we can't find it, then return result of search (fast hacky solution)
-          //  .switchIfEmpty(
+            //OR we can just save this operation if we can't find it, then return result of search (fast hacky solution)
+            //  .switchIfEmpty(
             //    save(sourceOperation)
-              //      .flatMapMaybe { storage.search(sourceOperation.description()) }
-           // )
+            //      .flatMapMaybe { storage.search(sourceOperation.description()) }
+            // )
             .map(this::deserialize)
             .map { createCacheResult(it, sourceOperation.description()) }
             .toSingle()
-            .onErrorReturn{
+            .onErrorReturn {
                 CacheResult(
                     sourceOperation,
                     false

--- a/cache/content-storage/src/main/java/com/github/e13mort/codeview/cache/ContentStorage.kt
+++ b/cache/content-storage/src/main/java/com/github/e13mort/codeview/cache/ContentStorage.kt
@@ -7,6 +7,7 @@ import io.reactivex.Single
 import java.nio.file.Path
 
 interface ContentStorage {
+    //FIXME searching by key returns ContentStorageItem with only Path, but previously we put Content in it
     fun search(key: String): Maybe<ContentStorageItem>
 
     fun <T : Content> put(key: String, content: Observable<T>): Single<ContentStorageItem>


### PR DESCRIPTION
I wrote a couple of comments in places that seemed suspicious to me.

After saving the Transformation into cache, we cannot use result of this operation, and just map result of saving to sourceOperation. My point is that you should return content of saved operation and wrap it as DumbTransformOperation

Also I add hacky but fast solution to resolve this issue and second not so hacky solution